### PR TITLE
Does github.event.inputs work for workflow_call: as well?

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -53,8 +53,8 @@ jobs:
         id: verify-changed-files
         with:
           files: |
-             ${{ inputs.directory }}/Dockerfile
-             ${{ inputs.directory }}/github_package_list.tsv
+             ${{ github.event.inputs.directory }}/Dockerfile
+             ${{ github.event.inputs.directory }}/github_package_list.tsv
 
       - name: Login as jhudsl-robot
         run: |
@@ -78,7 +78,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Get token
-        run: echo ${{ secrets.GH_PAT }} > ${{ inputs.directory }}/git_token.txt
+        run: echo ${{ secrets.GH_PAT }} > ${{ github.event.inputs.directory }}/git_token.txt
 
       - name: Build Docker image
         uses: docker/build-push-action@v2
@@ -86,8 +86,8 @@ jobs:
           push: false
           load: true
           context: ${{ inputs.directory }}
-          file: ${{ inputs.directory }}/Dockerfile
-          tags: ${{ inputs.tag }}
+          file: ${{ github.event.inputs.directory }}/Dockerfile
+          tags: ${{ github.event.inputs.tag }}
 
       # Login to Dockerhub
       - name: Login to DockerHub
@@ -99,5 +99,5 @@ jobs:
 
       # Push the Docker image if set to true from a manual trigger
       - name: Push Docker image if manual trigger set to true
-        if: ${{ inputs.dockerhubpush != 'false' }}
-        run: docker push ${{ inputs.tag }}
+        if: ${{ github.event.inputs.dockerhubpush != 'false' }}
+        run: docker push ${{ github.event.inputs.tag }}

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -24,19 +24,6 @@ on:
         required: false
       DOCKERHUB_TOKEN:
         required: false
-  workflow_dispatch:
-    inputs:
-      directory:
-        required: true
-        type: string
-      tag:
-        required: true
-        type: string
-      dockerhubpush:
-        description: 'Push to Dockerhub?'
-        required: false
-        default: 'false'
-        type: string
 
 jobs:
 
@@ -53,8 +40,8 @@ jobs:
         id: verify-changed-files
         with:
           files: |
-             ${{ github.event.inputs.directory }}/Dockerfile
-             ${{ github.event.inputs.directory }}/github_package_list.tsv
+             ${{ inputs.directory }}/Dockerfile
+             ${{ inputs.directory }}/github_package_list.tsv
 
       - name: Login as jhudsl-robot
         run: |
@@ -78,7 +65,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Get token
-        run: echo ${{ secrets.GH_PAT }} > ${{ github.event.inputs.directory }}/git_token.txt
+        run: echo ${{ secrets.GH_PAT }} > ${{ inputs.directory }}/git_token.txt
 
       - name: Build Docker image
         uses: docker/build-push-action@v2
@@ -86,8 +73,8 @@ jobs:
           push: false
           load: true
           context: ${{ inputs.directory }}
-          file: ${{ github.event.inputs.directory }}/Dockerfile
-          tags: ${{ github.event.inputs.tag }}
+          file: ${{ inputs.directory }}/Dockerfile
+          tags: ${{ inputs.tag }}
 
       # Login to Dockerhub
       - name: Login to DockerHub
@@ -99,5 +86,5 @@ jobs:
 
       # Push the Docker image if set to true from a manual trigger
       - name: Push Docker image if manual trigger set to true
-        if: ${{ github.event.inputs.dockerhubpush != 'false' }}
-        run: docker push ${{ github.event.inputs.tag }}
+        if: ${{ inputs.dockerhubpush != 'false' }}
+        run: docker push ${{ inputs.tag }}

--- a/.github/workflows/manual_dispatch.yml
+++ b/.github/workflows/manual_dispatch.yml
@@ -1,0 +1,32 @@
+# Candace Savonen May 2022
+
+name: Manual build of docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      directory:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+      dockerhubpush:
+        description: 'Push to Dockerhub?'
+        required: false
+        default: 'false'
+        type: string
+
+jobs:
+
+  build-it:
+    name: Build docker image on command
+    uses: ./.github/workflows/docker-test.yml
+    with:
+      directory: ${{github.event.inputs.directory}}
+      tag: ${{github.event.inputs.tag}}
+      dockerhubpush: ${{github.event.inputs.dockerhubpush}}
+    secrets:
+      GH_PAT: ${{ secrets.GH_PAT }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/bioconductor/Dockerfile
+++ b/bioconductor/Dockerfile
@@ -64,6 +64,3 @@ COPY github_package_list.tsv .
 RUN Rscript install_github.R \
   --packages github_package_list.tsv \
   --token git_token.txt
-
-# Set final workdir for commands
-WORKDIR /home/rstudio


### PR DESCRIPTION
For the `workflow_dispatch` version of the docker-test.yml, `inputs.directory` doesn't work but I think `github.event.inputs.directory` will, but the question is, will `github.event.inputs.directory` work for `workflow_call:`?