### PR TITLE
bump docker/login to v2

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -79,7 +79,7 @@ jobs:
       # Login to Dockerhub
       - name: Login to DockerHub
         if: ${{ inputs.dockerhubpush != 'false' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
The docker login isn't authenticating correctly: https://github.com/jhudsl/ottr_docker/actions/runs/4296174158/jobs/7487562379

and there's some other warnings about deprecations: 


```
Warning: The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```